### PR TITLE
fix bug in insertOrdered()

### DIFF
--- a/scripts/B2DstMu_skimCAND_v1.py
+++ b/scripts/B2DstMu_skimCAND_v1.py
@@ -149,6 +149,8 @@ def insertOrdered(list, el):
         for il in range(len(list)):
             if list[il] < el:
                 break
+        else:
+            il += 1
         # list = list[:il] + [el] + list[il:]
         return il, list[:il] + [el] + list[il:]
 

--- a/scripts/B2JpsiK_skimCAND_v1.py
+++ b/scripts/B2JpsiK_skimCAND_v1.py
@@ -119,6 +119,8 @@ def insertOrdered(list, el):
         for il in range(len(list)):
             if list[il] < el:
                 break
+        else:
+            il += 1
         # list = list[:il] + [el] + list[il:]
         return il, list[:il] + [el] + list[il:]
 

--- a/scripts/skimmer.py
+++ b/scripts/skimmer.py
@@ -93,6 +93,8 @@ def insertOrdered(list, el):
         for il in range(len(list)):
             if list[il] < el:
                 break
+        else:
+            il += 1
         # list = list[:il] + [el] + list[il:]
         return il, list[:il] + [el] + list[il:]
 


### PR DESCRIPTION
Previous version would not always insert things in correct order:

```python
>>> insertOrdered([3,2,1],0)
(2, [3, 2, 0, 1])
```

Haven't fully tested this yet, but I did verify it fixes this corner case.