### PR TITLE
allow events to move between control regions

### DIFF
--- a/Combine/runCombine.py
+++ b/Combine/runCombine.py
@@ -47,6 +47,91 @@ CMS_lumi.writeExtraText = 1
 CMS_lumi.extraText = "     Preliminary"
 donotdelete = []
 
+def get_ctrl_group(ds):
+    """
+    Add a column specifying the control region. Here, the control region number
+    is sort of like the control region expressed as an integer. It is a three
+    digit number where the number in the least significant digit represents the
+    charge of the first track (1 for positive, 2 for negative), the next digit
+    represents the charge of the second track, etc.
+
+    For example, ctrl == 0 represents the signal region, ctrl == 200 represents
+    the minus control region, etc.
+
+    The nice thing about this representation is that if you want to find out what
+    would happen if you didn't reconstruct the lowest pt track, you can just
+    compute ctrl//10. For example:
+
+        >>> ctrl = 222
+        >>> ctrl//10
+        22
+
+    This allows us to compute what would happen if events moved between the
+    control groups.
+    """
+    tk0 = np.where(ds['tkCharge_0'] == -1, 2, ds['tkCharge_0']).astype(int)
+    tk1 = np.where(ds['tkCharge_1'] == -1, 2, ds['tkCharge_1']).astype(int)
+    tk2 = np.where(ds['tkCharge_2'] == -1, 2, ds['tkCharge_2']).astype(int)
+    condlist = [ds['N_goodAddTks'] == 0,ds['N_goodAddTks'] == 1,ds['N_goodAddTks'] == 2,ds['N_goodAddTks'] == 3,ds['N_goodAddTks'] > 3]
+    choicelist = np.array([np.zeros_like(tk0),tk0,tk0*10+tk1,tk0*100+tk1*10+tk2,tk0*100+tk1*10+tk2])
+    return np.select(condlist,choicelist)
+
+def get_min_pt(ds):
+    condlist = [ds['N_goodAddTks'] == 0,ds['N_goodAddTks'] == 1,ds['N_goodAddTks'] == 2,ds['N_goodAddTks'] == 3,ds['N_goodAddTks'] > 3]
+    choicelist = np.array([np.zeros_like(ds['tkPt_0']),ds['tkPt_0'],ds['tkPt_1'],ds['tkPt_2'],ds['tkPt_2']])
+    return np.select(condlist,choicelist)
+
+def get_ctrl_weights(ds,pt_min=0,pt_max=1,fraction=0.3,epsilon=1e-10):
+    """
+    Returns weights for events which move between control regions due to the
+    lowest pt track not passing all cuts. For example, if extra tracks in data
+    are less likely to be reconstructed or pass the goodness of fit tests with
+    the vertex, they will end up being in a different control region. The
+    possible movements of the events are: ppp -> pp, ppm -> pp, pmp -> pm, pmm
+    -> pm, mmp -> mm, mmm -> mm, ,pm -> p, mp -> m, p -> signal, m -> signal.
+
+    Returns a tuple (weight, up, down), where weight is the default weights
+    (which assigns `epsilon` to all duplicate events and 1 to all original
+    events), up is the weights for when events move divided by the original
+    weights, and down is the weights for when data is *more* likely to
+    reconstruct extra tracks divided by the original weights (currently assumed
+    to not happen, since this seems unlikely and there is no way currently to
+    know the pt of tracks which *almost* got reconstructed).
+
+    Parameters
+    ----------
+    ds: dataframe
+        Events to calculae weights for.
+    pt_min: float
+        The minimum pt of events being moved.
+    pt_max: float
+        The maximum pt of events being moved.
+    fraction: float
+        The fraction of events whose lowest pt track falls in between `pt_min`
+        and `pt_max` which are moved.
+    epsilon: float
+        Small weight given to duplicate events.
+    """
+    orig = ds['ctrl'] == ds['ctrl2']
+    w = np.where(orig,1,epsilon).astype(float)
+    down = w
+
+    # The conditions here are:
+    #
+    #     1. This is an original event with no extra tracks.
+    #     2. This is an original event which got moved.
+    #     3. This is an original event which didn't get moved.
+    #     4. This is a duplicate event which got moved.
+    #     5. This is a duplicate event which didn't get moved.
+    pt = (ds['tkPt_last'] > pt_min) & (ds['tkPt_last'] < pt_max)
+    condlist = [orig & (ds['ctrl'] == 0),
+                orig & pt,
+                orig & ~pt,
+                ~orig & pt,
+                ~orig & ~pt]
+    up = np.select(condlist,[1,1-fraction,1,fraction,0])
+    return w, up/w, down/w
+
 import argparse
 parser = argparse.ArgumentParser(description='Script used to run combine on the R(D*) analysis.',
                                  epilog='Test example: ./runCombine.py -c low',
@@ -313,29 +398,29 @@ def cleanPreviousResults():
 ########################### -------- Create histrograms ------------------ #########################
 controlRegSel = {}
 def selfun__TkPlus(ds):
-    sel = np.logical_and(ds['N_goodAddTks'] == 1, ds['tkCharge_0'] > 0)
+    sel = ds['ctrl2'] == 1
     return sel
 controlRegSel['p_'] = selfun__TkPlus
 
 def selfun__TkMinus(ds):
-    sel = np.logical_and(ds['N_goodAddTks'] == 1, ds['tkCharge_0'] < 0)
+    sel = ds['ctrl2'] == 2
     return sel
 controlRegSel['m_'] = selfun__TkMinus
 
 def selfun__TkPlusMinus(ds):
-    sel = np.logical_and(ds['tkCharge_0']+ds['tkCharge_1'] == 0, ds['N_goodAddTks'] == 2)
+    sel = (ds['ctrl2'] == 12) | (ds['ctrl2'] == 21)
     sel = np.logical_and(ds['massVisTks'] < 5.55, sel)
     return sel
 controlRegSel['pm'] = selfun__TkPlusMinus
 
 def selfun__TkMinusMinus(ds):
-    sel = np.logical_and(ds['tkCharge_0']+ds['tkCharge_1'] == -2, ds['N_goodAddTks'] == 2)
+    sel = ds['ctrl2'] == 22
     sel = np.logical_and(ds['massVisTks'] < 5.3, sel)
     return sel
 controlRegSel['mm'] = selfun__TkMinusMinus
 
 def selfun__TkPlusPlus(ds):
-    sel = np.logical_and(ds['tkCharge_0']+ds['tkCharge_1'] == +2, ds['N_goodAddTks'] == 2)
+    sel = ds['ctrl2'] == 11
     sel = np.logical_and(ds['massVisTks'] < 5.3, sel)
     return sel
 controlRegSel['pp'] = selfun__TkPlusPlus
@@ -409,6 +494,38 @@ def loadDatasets(category, loadRD):
         locRD = dataDir+'/skimmed'+args.skimmedTag+'/B2DstMu_{}_{}'.format(creation_date, category.name)
         dSet['data'] = pd.DataFrame(rtnp.root2array(locRD + '_corr.root'))
         dSetTkSide['data'] = pd.DataFrame(rtnp.root2array(locRD + '_trkCtrl_corr.root'))
+
+    for name in dSet:
+        dSet[name]['ctrl'] = get_ctrl_group(dSet[name])
+        dSet[name]['ctrl2'] = dSet[name]['ctrl']
+        dSet[name]['tkPt_last'] = get_min_pt(dSet[name])
+
+    for name in dSetTkSide:
+        dSetTkSide[name]['ctrl'] = get_ctrl_group(dSetTkSide[name])
+        dSetTkSide[name]['ctrl2'] = dSetTkSide[name]['ctrl']
+        dSetTkSide[name]['tkPt_last'] = get_min_pt(dSetTkSide[name])
+        if 'data' not in name:
+            # Here is where we duplicate the MC to allow us to move events
+            # between control regions.
+            dup = dSetTkSide[name].copy()
+            dup = dup[dup['ctrl'] != 0]
+            dup['ctrl2'] = dup['ctrl']//10
+            # Set the massHadTks and massVisTks column equal to what it would
+            # be had we missed the last track.
+            condlist = [dup['ctrl2'] == 0, dup['ctrl2'] < 10, dup['ctrl2'] < 100, dup['ctrl2'] >= 100]
+            choicelist = [dup['massHadTks1'], dup['massHadTks1'], dup['massHadTks2'], dup['massHadTks2']]
+            dup['massHadTks'] = np.select(condlist,choicelist)
+            choicelist = [dup['massVisTks1'], dup['massVisTks1'], dup['massVisTks2'], dup['massVisTks2']]
+            dup['massVisTks'] = np.select(condlist,choicelist)
+            # Make sure we didn't accidentally copy any events which don't
+            # move.
+            if (dup['ctrl2'] == dup['ctrl']).any():
+                raise Exception("ctrl2 == ctrl!")
+            # Now put events in the correct dictionary since we have separate
+            # dictionaries for the signal and track control regions
+            dSetTkSide[name] = pd.concat((dSetTkSide[name],dup[dup['ctrl2'] != 0]),ignore_index=True)
+            if name in dSet:
+                dSet[name] = pd.concat((dSet[name],dup[dup['ctrl2'] == 0]),ignore_index=True)
 
     if args.useMVA:
         fname = '/storage/af/group/rdst_analysis/BPhysics/data/kinObsMVA/clfGBC_tauVall_{}{}.p'.format(args.useMVA, category.name)
@@ -484,8 +601,12 @@ def loadDatasets(category, loadRD):
                         raise
                     sel = np.logical_and(sel, np.logical_and(dSet[k][var] > low, dSet[k][var] < high))
 
+                orig = dSet[k]['ctrl'] == dSet[k]['ctrl2']
                 dSet[k] = dSet[k][sel]
-                corrScaleFactors[k] = np.sum(sel)/float(sel.shape[0])
+                # We don't want to include the duplicate events here, so we
+                # compute the correction scale factors only for those events
+                # which aren't duplicates.
+                corrScaleFactors[k] = np.sum(sel[orig])/float(sel[orig].shape[0])
 
                 sel = np.ones_like(dSetTkSide[k]['q2']).astype(np.bool)
                 for var, low, high in addCuts:
@@ -508,8 +629,12 @@ def loadDatasets(category, loadRD):
                         auxSel = np.logical_or( np.logical_not(controlRegSel[region](dSetTkSide[k])), thisSel)
                         sel = np.logical_and(sel, auxSel)
 
+                orig = dSetTkSide[k]['ctrl'] == dSetTkSide[k]['ctrl2']
                 dSetTkSide[k] = dSetTkSide[k][sel]
-                corrScaleFactors[k+'_tk'] = np.sum(sel)/float(sel.shape[0])
+                # We don't want to include the duplicate events here, so we
+                # compute the correction scale factors only for those events
+                # which aren't duplicates.
+                corrScaleFactors[k+'_tk'] = np.sum(sel[orig])/float(sel[orig].shape[0])
 
 
     return MCsample, dSet, dSetTkSide
@@ -726,12 +851,12 @@ def createHistograms(category):
 
     def weightsSoftTrackEff(ds, ptList, w=None, s=None, bin=None, size=None):
         if w is None or s is None:
-            weight = binnnedSoftTrackEff(ds[ptList[0]], bin, size)
-            for v in ptList[1:]:
+            weight = np.ones_like(ds['mu_pt'])
+            for v in ptList:
                 weight *= binnnedSoftTrackEff(ds[v], bin, size)
         else:
-            weight = fSoftTrackEff(ds[ptList[0]], w, s)
-            for v in ptList[1:]:
+            weight = np.ones_like(ds['mu_pt'])
+            for v in ptList:
                 weight *= fSoftTrackEff(ds[v], w, s)
         return weight
 
@@ -867,13 +992,16 @@ def createHistograms(category):
         print '\n----------->', n, '<-------------'
         wVar = {}
         weights = {}
+        if 'data' not in n:
+            weights['ctrl'], wVar['ctrlUp'], wVar['ctrlDown'] = get_ctrl_weights(ds)
         if n == 'dataSS_DstMu':
             nTotSelected = ds['q2'].shape[0]
             nTotExp = ds['q2'].shape[0]
         else:
             sMC = MCsample[n]
 
-            nTotSelected = ds['q2'].shape[0]
+            orig = ds['ctrl'] == ds['ctrl2']
+            nTotSelected = ds[orig]['q2'].shape[0]
             print 'N tot selected: {:.1f}k'.format(1e-3*nTotSelected)
             totalCounting[1] += 1e-3*nTotSelected
             nGenExp = sMC.effMCgen['xsec'][0] * expectedLumi[category.name] * data_over_MC_overallNorm
@@ -1462,6 +1590,8 @@ def createHistograms(category):
         print '\n----------->', n, '<-------------'
         wVar = {}
         weights = {}
+        if 'data' not in n:
+            weights['ctrl'], wVar['ctrlUp'], wVar['ctrlDown'] = get_ctrl_weights(ds)
         if n == 'dataSS_DstMu':
             nTotExp = ds['q2'].shape[0]
         else:
@@ -1527,7 +1657,7 @@ def createHistograms(category):
             weights['muonIdSF'], _, _ = computeMuonIDSF(ds)
 
             print 'Including soft track pT corrections'
-            partList = ['K_pt', 'pi_pt', 'pis_pt', 'tkPt_0', 'tkPt_1']
+            partList = ['K_pt', 'pi_pt', 'pis_pt']
             for nBin in range(len(softPtUnc)):
                 refPt = '{:.0f}'.format(np.round(np.mean(softPtUnc[nBin][:-1])*1e3))
                 wVar['softTrkEff_'+refPt+'Up'] = weightsSoftTrackEff(ds, partList, bin=nBin, size=+1)
@@ -1561,12 +1691,18 @@ def createHistograms(category):
             cname = 'addTk_pt_cali_'+category.name
             w, auxVarDic = computeKinCalWeights(ds, 'tkPt_0', cname, cal_addTK_pt)
             # Apply it only if they are not from main B
-            sel = ds['MC_tkFromMainB_0'] < 0.5
-            print 'Affecting {:.1f}% of additional tracks'.format(100*np.sum(ds['MC_tkFromMainB_0'] < 0.5)/float(ds.shape[0]))
+            orig = ds['ctrl'] == ds['ctrl2']
+            sel = (ds['MC_tkFromMainB_0'] < 0.5) & orig
+            print 'Affecting {:.1f}% of additional tracks'.format(100*np.sum(sel)/float(ds[orig].shape[0]))
             weights[cname] = np.where(sel, w * np.sum(sel) / np.sum(w[sel]), 1)
-            print 'Normalization change: {:.3f}'.format(np.sum(weights[cname])/ float(weights[cname].shape[0]))
+            print 'Normalization change: {:.3f}'.format(np.sum(weights[cname][orig])/ float(weights[cname][orig].shape[0]))
             for k in auxVarDic.keys():
                 wVar[k] = np.where(sel, auxVarDic[k] *  np.sum(sel) / np.sum((weights[cname]*auxVarDic[k])[sel]), 1. )
+            # Now, apply the same correction to duplicate tracks
+            sel = (ds['MC_tkFromMainB_0'] < 0.5) & ~orig
+            weights[cname] *= np.where(sel, w * np.sum(sel) / np.sum(w[sel]), 1)
+            for k in auxVarDic.keys():
+                wVar[k] *= np.where(sel, auxVarDic[k] *  np.sum(sel) / np.sum((weights[cname]*auxVarDic[k])[sel]), 1. )
 
         ############################
         # Form factor correction
@@ -1854,7 +1990,8 @@ def createHistograms(category):
             mcType = 'bare' if args.bareMC else 'corr'
             auxName = category.name + 'trkCtrl_' + mcType + '_' + card_name + '.root'
 
-            wDf = pd.DataFrame.from_dict({'central': weightsCentral*nTotExp/float(weightsCentral.shape[0]) })
+            orig = ds['ctrl'] == ds['ctrl2']
+            wDf = pd.DataFrame.from_dict({'central': weightsCentral*nTotExp/float(weightsCentral[orig].shape[0]) })
             for k, w in wVar.iteritems():
                 if k:
                     wDf[k] = w*wDf['central']
@@ -1873,11 +2010,14 @@ def createHistograms(category):
             elif n == 'dataSS_DstMu' and k == 'pm':
                 selFun = controlRegSel['mm']
             sel[k] = selFun(ds)
+            orig = ds['ctrl'] == ds['ctrl2']
+            if 'data' not in n:
+                sel[k] &= orig
             nTotSel = float(np.sum(sel[k]))
-            nExp = nTotExp * nTotSel / sel[k].shape[0]
+            nExp = nTotExp * nTotSel / sel[k][orig].shape[0]
             # if n == 'dataSS_DstMu' and k == 'mm':
             #     nExp *= 1e-3
-            nAux = nTotExp * np.sum(weightsCentral[sel[k]]) / sel[k].shape[0]
+            nAux = nTotExp * np.sum(weightsCentral[sel[k]]) / sel[k][orig].shape[0]
             table.add_row([k] + '{:.0f} {:.0f} {:.0f}'.format(nTotSel, nExp, nAux).split(' '))
             latexTableString[k] = '{:.0f} ({:.0f})'.format(nAux, nTotSel)
             if not k in totalCounting.keys():
@@ -2876,6 +3016,8 @@ def createSingleCard(histo, category, fitRegionsOnly=False):
         if k.startswith(processOrder[0]+'__softTrkEff') and k.endswith('Up'):
             n = k[k.find('__')+2:-2]
             card += n+' shape' + mcProcStr*nCat + '\n'
+
+    card += 'ctrl shape' + mcProcStr*nCat + '\n'
 
     # B eta uncertainty
     names = []

--- a/scripts/B2DstMu_skimCAND_v1.py
+++ b/scripts/B2DstMu_skimCAND_v1.py
@@ -287,6 +287,7 @@ def extractEventInfos(j, ev, corr=None):
     e.UmissTk = []
 
     p4_sumGoodTks = rt.TLorentzVector()
+    p4_tks = []
     for jj in range(idx_st, idx_stop):
         pval = ev.tksAdd_pval[jj]
         if pval < 0.1:
@@ -351,12 +352,21 @@ def extractEventInfos(j, ev, corr=None):
                 e.MC_tkMotherPdgId.insert(idx, ev.MC_addTk_pdgIdMother[jj])
                 e.MC_tkMotherMotherPdgId.insert(idx, ev.MC_addTk_pdgIdMotherMother[jj])
 
+            p4_tks.insert(idx,p4_tk)
             p4_sumGoodTks += p4_tk
 
+    while len(p4_tks) < 3:
+        p4_tks.append(rt.TLorentzVector())
 
     p4_vis_wTks = p4_vis + p4_sumGoodTks
+    e.massVisTks1 = (p4_vis + p4_tks[0]).M()
+    e.massVisTks2 = (p4_vis + p4_tks[0] + p4_tks[1]).M()
+    e.massVisTks3 = (p4_vis + p4_tks[0] + p4_tks[1] + p4_tks[2]).M()
     e.massVisTks = p4_vis_wTks.M()
     e.massHadTks = (p4_Dst + p4_sumGoodTks).M()
+    e.massHadTks1 = (p4_Dst + p4_tks[0]).M()
+    e.massHadTks2 = (p4_Dst + p4_tks[0] + p4_tks[1]).M()
+    e.massHadTks3 = (p4_Dst + p4_tks[0] + p4_tks[1] + p4_tks[2]).M()
     e.massHadTks_DstMassConstraint = (p4_Dst + p4_sumGoodTks).M() - p4_Dst.M() + m_Dst
 
     if e.N_goodAddTks == 2:
@@ -585,7 +595,10 @@ def makeSelection(inputs):
                    evEx.mass2MissTk[0], evEx.mass2MissTk[1], evEx.mass2MissTk[2],
                    evEx.UmissTk[0], evEx.UmissTk[1], evEx.UmissTk[2],
                    evEx.massTks_pipi, evEx.massTks_KK, evEx.massTks_piK, evEx.massTks_Kpi,
-                   evEx.massVisTks, evEx.massHadTks, evEx.massHadTks_DstMassConstraint,
+                   evEx.massVisTks, evEx.massHadTks,
+                   evEx.massVisTks1, evEx.massVisTks2, evEx.massVisTks3,
+                   evEx.massHadTks1, evEx.massHadTks2, evEx.massHadTks3,
+                   evEx.massHadTks_DstMassConstraint,
                    evEx.M2missTks, evEx.q2Tks,
                    evEx.EmissTks, evEx.PmissTks, evEx.UmissTks,
                    evEx.N_goodAddNeu,
@@ -1045,7 +1058,14 @@ def create_dSet(n, filepath, cat, applyCorrections=False, skipCut=[], trkControl
                        'tkMassMiss2_0', 'tkMassMiss2_1', 'tkMassMiss2_2',
                        'tkUmiss_0', 'tkUmiss_1', 'tkUmiss_2',
                        'massTks_pipi', 'massTks_KK', 'massTks_piK', 'massTks_Kpi',
-                       'massVisTks', 'massHadTks', 'massHadTks_DstMassConstraint',
+                       'massVisTks', 'massHadTks',
+                       'massVisTks1',
+                       'massVisTks2',
+                       'massVisTks3',
+                       'massHadTks1',
+                       'massHadTks2',
+                       'massHadTks3',
+                       'massHadTks_DstMassConstraint',
                        'M2missTks', 'q2Tks',
                        'EmissTks', 'PmissTks', 'UmissTks',
                        'N_goodAddNeu',


### PR DESCRIPTION
This commit updates runCombine.py to allow events with low pt extra
tracks to move between control regions.

I haven't finished testing this, so please don't merge.

Would like to get any feedback too if you see anything that looks wrong.