### PR TITLE
fix a bug to add the addTk_pt_cali_* parameters

### DIFF
--- a/Combine/runCombine.py
+++ b/Combine/runCombine.py
@@ -2863,7 +2863,7 @@ def createSingleCard(histo, category, fitRegionsOnly=False):
         card += 'randTksPU'+auxTag+' shape' + aux + '\n'
 
         cname = 'addTk_pt_cali_'+category.name
-        for k in histo.values()[0].keys():
+        for k in histo['ctrl_p__mHad'].keys():
             if k.startswith(processOrder[0]+'__'+cname) and k.endswith('Up'):
                 n = k[k.find('__')+2:-2]
                 print n


### PR DESCRIPTION
Previously the addTk_pt_cali_* parameters weren't being fitted because
the code looked at the first histogram, which might have been a signal
region histogram without these parameters.