### PR TITLE
make root ignore command line options

### DIFF
--- a/Combine/runCombine.py
+++ b/Combine/runCombine.py
@@ -27,6 +27,7 @@ import subprocess
 
 import uproot as ur
 import ROOT as rt
+rt.PyConfig.IgnoreCommandLineOptions = True
 rt.gErrorIgnoreLevel = rt.kError
 rt.RooMsgService.instance().setGlobalKillBelow(rt.RooFit.ERROR)
 import root_numpy as rtnp


### PR DESCRIPTION
This commit makes ROOT ignore the command line options so that when you run:

```console
$ ./runCombine.py --help
```

you actually get the correct help message and not ROOT's help message. Previous behavior:

```console
[alatorre@login-2 Combine]$ ./runCombine.py --help

Usage: python [-l] [-b] [-n] [-q] [dir] [[file:]data.root] [file1.C ... fileN.C]
Options:
  -b : run in batch mode without graphics
  -x : exit on exception
  -e expression: request execution of the given C++ expression
  -n : do not execute logon and logoff macros as specified in .rootrc
  -q : exit after processing command line macro files
  -l : do not show splash screen
  -t : enable thread-safety and implicit multi-threading (IMT)
 --notebook : execute ROOT notebook
 dir : if dir is a valid directory cd to it before executing

  -?      : print usage
  -h      : print usage
  --help  : print usage
  -config : print ./configure options
  -memstat : run with memory usage monitoring
```

New behavior:

```console
[alatorre@login-2 Combine]$ ./runCombine.py --help
usage: runCombine.py [-h] [--HELP] [--cardTag CARDTAG]
                     [--category {single,low,mid,high,comb}]
                     [--skimmedTag SKIMMEDTAG] [--bareMC BAREMC]
                     [--maxEventsToLoad MAXEVENTSTOLOAD]
                     [--calBpT {poly,none}] [--schemeFF {CLN,BLPR,NoFF}]
                     [--lumiMult LUMIMULT] [--useMVA {False,v3}]
                     [--signalRegProj1D {M2_miss,Est_mu,U_miss}]
                     [--unblinded UNBLINDED] [--noLowq2]
                     [--controlRegions [CONTROLREGIONS [CONTROLREGIONS ...]]]
                     [--correlate_tkPVfrac] [--freezeFF] [--freeMuBr FREEMUBR]
                     [--asimov] [--noMCstats] [--dumpWeightsTree]
                     [--step {clean,histos,preFitPlots,shapeVarPlots,card,workspace,bias,scan,catComp,fitDiag,postFitPlots,uncBreakdownScan,uncBreakdownTable,externalize,impacts,GoF} [{clean,histos,preFitPlots,shapeVarPlots,card,workspace,bias,scan,catComp,fitDiag,postFitPlots,uncBreakdownScan,uncBreakdownTable,externalize,impacts,GoF} ...]]
                     [--submit] [--runInJob] [--validateCard]
                     [--decorrelateFFpars] [--forceRDst] [--seed SEED]
                     [--RDstLims RDSTLIMS [RDSTLIMS ...]] [--runBiasToys]
                     [--nToys NTOYS] [--toysRDst TOYSRDST] [--runBiasAnalysis]
                     [--scanStrategy SCANSTRATEGY]
                     [--maskScan MASKSCAN [MASKSCAN ...]] [--scanTag SCANTAG]
                     [--freezeParsScan FREEZEPARSSCAN [FREEZEPARSSCAN ...]]
                     [--externPars EXTERNPARS [EXTERNPARS ...]]
                     [--externSigma EXTERNSIGMA] [--externTag EXTERNTAG]
                     [--externCenter {preFit,postFit}] [--collectImpacts]
                     [--subOnlyImpacts]
                     [--algoGoF {Sat,AD,KS} [{Sat,AD,KS} ...]]
                     [--maskEvalGoF MASKEVALGOF [MASKEVALGOF ...]]
                     [--tagGoF TAGGOF] [--showPlots] [--showCard]
                     [--verbose VERBOSE]

Script used to run combine on the R(D*) analysis.

optional arguments:
  -h, --help            show this help message and exit
  --HELP, -H            Print help message.
  --cardTag CARDTAG, -v CARDTAG
                        Card name initial tag.
  --category {single,low,mid,high,comb}, -c {single,low,mid,high,comb}
                        Category.
  --skimmedTag SKIMMEDTAG
                        Tag to append to the skimmed directory.
  --bareMC BAREMC       Use bare MC instead of the corrected one.
  --maxEventsToLoad MAXEVENTSTOLOAD
                        Max number of MC events to load per sample.
  --calBpT {poly,none}  Form factor scheme to use.
  --schemeFF {CLN,BLPR,NoFF}
                        Form factor scheme to use.
  --lumiMult LUMIMULT   Luminosity multiplier for asimov dataset. Only works
                        when asimov=True
  --useMVA {False,v3}   Use MVA in the fit.
  --signalRegProj1D {M2_miss,Est_mu,U_miss}
                        Use 1D projections in signal region instead of the
                        unrolled histograms
  --unblinded UNBLINDED
                        Unblind the fit regions.
  --noLowq2             Mask the low q2 signal regions.
  --controlRegions [CONTROLREGIONS [CONTROLREGIONS ...]]
                        Control regions to use
  --correlate_tkPVfrac  Correlate tkPVfrac in all categories.
  --freezeFF            Freeze form factors to central value.
  --freeMuBr FREEMUBR   Make muon branching fraction with a rate parameter
                        (flat prior).
  --asimov              Use Asimov dataset insted of real data.
  --noMCstats           Do not include MC stat systematic.
  --dumpWeightsTree     Dump tree with weights for skimmed events.
  --step {clean,histos,preFitPlots,shapeVarPlots,card,workspace,bias,scan,catComp,fitDiag,postFitPlots,uncBreakdownScan,uncBreakdownTable,externalize,impacts,GoF} [{clean,histos,preFitPlots,shapeVarPlots,card,workspace,bias,scan,catComp,fitDiag,postFitPlots,uncBreakdownScan,uncBreakdownTable,externalize,impacts,GoF} ...], -s {clean,histos,preFitPlots,shapeVarPlots,card,workspace,bias,scan,catComp,fitDiag,postFitPlots,uncBreakdownScan,uncBreakdownTable,externalize,impacts,GoF} [{clean,histos,preFitPlots,shapeVarPlots,card,workspace,bias,scan,catComp,fitDiag,postFitPlots,uncBreakdownScan,uncBreakdownTable,externalize,impacts,GoF} ...]
                        Analysis steps to run.
  --submit              Submit a job instead of running the call
                        interactively.
  --runInJob            Not for user, reserved to jobs calls.
  --validateCard        Run combine card validation.
  --decorrelateFFpars   Decorrelte form factors parameters
  --forceRDst           Perform fit fixing R(D*) to 0.295
  --seed SEED           Seed used by Combine
  --RDstLims RDSTLIMS [RDSTLIMS ...]
                        Initial boundaries for R(D*).
  --runBiasToys         Only generate toys and run scans for bias, do not
                        collect results.
  --nToys NTOYS         Number of toys to run
  --toysRDst TOYSRDST   R(D*) value used to generate the toys.
  --runBiasAnalysis     Only analyze bias scans which have been previously
                        produced.
  --scanStrategy SCANSTRATEGY
                        Minimizer strategy for the scan.
  --maskScan MASKSCAN [MASKSCAN ...]
                        Channels to mask during likelyhood scan. If this list
                        is non empty, the full card is used (default is
                        fitregionsOnly).
  --scanTag SCANTAG
  --freezeParsScan FREEZEPARSSCAN [FREEZEPARSSCAN ...]
  --externPars EXTERNPARS [EXTERNPARS ...]
                        Parameters to externalize.
  --externSigma EXTERNSIGMA
                        Externalization sigmas.
  --externTag EXTERNTAG
                        Externalization tag.
  --externCenter {preFit,postFit}
                        Externalization tag.
  --collectImpacts      Only collect impact fits which have been previously
                        run
  --subOnlyImpacts      Only submit impact fits, do not collect results
  --algoGoF {Sat,AD,KS} [{Sat,AD,KS} ...]
                        Algorithm to be used for the goodness of fit test
  --maskEvalGoF MASKEVALGOF [MASKEVALGOF ...]
                        Additional channels to mask during GoF evaluation
  --tagGoF TAGGOF
  --showPlots           Show plots by setting ROOT batch mode OFF (default ON)
  --showCard            Dump card on std outoput
  --verbose VERBOSE     Run verbosity.

Test example: ./runCombine.py -c low
```
