### PR TITLE
Killing slipped in signal

### DIFF
--- a/Combine/runCombine.py
+++ b/Combine/runCombine.py
@@ -1158,6 +1158,13 @@ def createHistograms(category):
 
 
         ############################
+        # Cleaning signal form slipped in events
+        ############################
+        if n in ['mu', 'tau']:
+            weights['kill_slipped_in'] = np.where( ds['procId_signal'] == {'tau': 0, 'mu': 1}[n], 1, 0)
+            print 'Surviving after killing slipped in {:.3f}%'.format(100*np.sum(weights['kill_slipped_in'])/float(ds.shape[0]))
+
+        ############################
         # Dstst resonance mix
         ############################
         if re.match('B[du]_MuDstPi\Z', n):
@@ -1629,6 +1636,13 @@ def createHistograms(category):
                     ratesRatio[23] = sMC.effCand['rate_D2sBLOP_central']/sMC.effCand['rate_D2sBLOP_'+parName+var]
                     wVar['FF_B2'+tag] = np.where(selDstst, (ds['wh_'+tag]/ds['wh_D2S_BLOPCentral'])*ratesRatio[procId_Dstst], 1.)
                     wVar['FF_B2'+tag][np.isnan(wVar['FF_B2'+tag])] = 0.
+
+        ############################
+        # Cleaning signal form slipped in events
+        ############################
+        if n in ['mu', 'tau']:
+            weights['kill_slipped_in'] = np.where( ds['procId_signal'] == {'tau': 0, 'mu': 1}[n], 1, 0)
+            print 'Surviving after killing slipped in {:.3f}%'.format(100*np.sum(weights['kill_slipped_in'])/float(ds.shape[0]))
 
         ############################
         # Dstst resonance mix


### PR DESCRIPTION
Removing events from MC which splipped in in signal samples

Minor changes to the output

```
+----------------------------------------------------------------------------------------------------+
|                                                low                                                 |
+----------------------------+-------------+------------+----------+-------------------------+-------+
|          Version           |   Sat. GoF  |  Scan [%]  | Cat comp | Top pulls               | [sig] |
+----------------------------+-------------+------------+----------+-------------------------+-------+
|           v15_1            | 229 (22.5%) | 0.0 + 12.9 |    -     | ~ctrl_mm_mHad_bin1      | -2.14 |
|                            |             |     - 0.0  |          | brB_DstPiMuNu_1         |  1.95 |
|                            |             |            |          | ctrlNormBToDstHcMu7_IP4 |  1.42 |
|                            |             |            |          | ~ctrl_mm_mHad_bin11     | -1.19 |
|                            |             |            |          |                         |       |
| v15_1_killSplippedInSignal | 229 (21.5%) | 0.0 + 13.3 |    -     | ~ctrl_mm_mHad_bin1      | -2.14 |
|                            |             |     - 0.0  |          | brB_DstPiMuNu_1         |  1.95 |
|                            |             |  < 0.342   |          | ctrlNormBToDstHcMu7_IP4 |  1.42 |
|                            |             |            |          | ~ctrl_mm_mHad_bin11     | -1.19 |
+----------------------------+-------------+------------+----------+-------------------------+-------+

+-----------------------------------------------------------------------------------------------+
|                                              mid                                              |
+----------------------------+-------------+------------+----------+--------------------+-------+
|          Version           |   Sat. GoF  |  Scan [%]  | Cat comp | Top pulls          | [sig] |
+----------------------------+-------------+------------+----------+--------------------+-------+
|           v15_1            | 225 (33.0%) | 0.0 + 15.9 |    -     | brB_DstPiMuNu_1    |  2.31 |
|                            |             |     - 0.0  |          | ~ctrl_mm_mHad_bin6 | -1.80 |
|                            |             |            |          | brB_DstPiPiMuNu_4  |  1.65 |
|                            |             |            |          | Bd_DDs1Br          |  1.59 |
|                            |             |            |          |                    |       |
| v15_1_killSplippedInSignal | 225 (25.0%) | 0.0 + 15.8 |    -     | brB_DstPiMuNu_1    |  2.31 |
|                            |             |     - 0.0  |          | ~ctrl_mm_mHad_bin6 | -1.80 |
|                            |             |  < 0.367   |          | brB_DstPiPiMuNu_4  |  1.65 |
|                            |             |            |          | Bd_DDs1Br          |  1.58 |
+----------------------------+-------------+------------+----------+--------------------+-------+

+----------------------------------------------------------------------------------------------+
|                                             high                                             |
+----------------------------+------------+-----------+----------+---------------------+-------+
|          Version           |  Sat. GoF  |  Scan [%] | Cat comp | Top pulls           | [sig] |
+----------------------------+------------+-----------+----------+---------------------+-------+
|           v15_1            | 254 (5.0%) | 0.0 + 3.8 |    -     | ~ctrl_pm_mVis_bin7  | -2.05 |
|                            |            |     - 0.0 |          | ~ctrl_pm_mVis_bin11 |  1.78 |
|                            |            |           |          | ~ctrl_pm_mVis_bin3  | -1.73 |
|                            |            |           |          | ~ctrl_pm_mVis_bin9  | -1.50 |
|                            |            |           |          |                     |       |
| v15_1_killSplippedInSignal | 254 (3.0%) | 0.0 + 3.9 |    -     | ~ctrl_pm_mVis_bin7  | -2.04 |
|                            |            |     - 0.0 |          | ~ctrl_pm_mVis_bin11 |  1.77 |
|                            |            |  < 0.181  |          | ~ctrl_pm_mVis_bin3  | -1.73 |
|                            |            |           |          | ~ctrl_pm_mVis_bin9  | -1.49 |
+----------------------------+------------+-----------+----------+---------------------+-------+

+-------------------------------------------------------------------------------------------------+
|                                              comb                                               |
+----------------------------+------------+-----------+----------+------------------------+-------+
|          Version           |  Sat. GoF  |  Scan [%] | Cat comp | Top pulls              | [sig] |
+----------------------------+------------+-----------+----------+------------------------+-------+
|           v15_1            | 720 (2.0%) | 0.0 + 9.5 |   100%   | ~low_ctrl_mm_mHad_bin1 | -2.13 |
|                            |            |     - 0.0 |          | brB_DstPiMuNu_1        |  2.11 |
|                            |            |  < 0.244  |          | B2DstCLNeig2           |  2.00 |
|                            |            |           |          | brB_DstPiPiMuNu_0      | -1.86 |
|                            |            |           |          |                        |       |
| v15_1_killSplippedInSignal |     -      | 0.0 + 9.3 |    -     | ~low_ctrl_mm_mHad_bin1 | -2.13 |
|                            |            |     - 0.0 |          | brB_DstPiMuNu_1        |  2.11 |
|                            |            |  < 0.247  |          | B2DstCLNeig2           |  2.00 |
|                            |            |           |          | brB_DstPiPiMuNu_0      | -1.86 |
+----------------------------+------------+-----------+----------+------------------------+-------+
```